### PR TITLE
Update vm-proxy.rb Formula to use Formula.service

### DIFF
--- a/Formula/vm-proxy.rb
+++ b/Formula/vm-proxy.rb
@@ -9,31 +9,12 @@ class VmProxy < Formula
     bin.install "vm-proxy"
   end
 
-  plist_options :startup => false
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>#{plist_name}</string>
-    <key>Program</key>
-    <string>#{bin}/vm-proxy</string>
-    <key>WorkingDirectory</key>
-    <string>#{HOMEBREW_PREFIX}</string>
-    <key>StandardOutPath</key>
-    <string>#{var}/log/vm-proxy/vm-proxy.log</string>
-    <key>StandardErrorPath</key>
-    <string>#{var}/log/vm-proxy/vm-proxy.log</string>
-    <key>RunAtLoad</key>
-    <true/>
-  </dict>
-</plist>
-...
-
-    EOS
+  service do
+    run bin/"vm-proxy"
+    require_root false
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/vm-proxy/vm-proxy.log"
+    error_log_path var/"log/vm-proxy/vm-proxy.log"
   end
 
   test do


### PR DESCRIPTION
# Summary

- Uses new `service` block in Formula class
- Fixes all deprecation/disabled field errors

This fixes the following error:

```rb
Error: vm-proxy: Calling plist_options is disabled! Use service.require_root instead.
Please report this issue to the blacktop/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/blacktop/homebrew-tap/Formula/vm-proxy.rb:12
```

# References

- [Formula Cookbook: Service Files](https://docs.brew.sh/Formula-Cookbook#service-files)

- [`Formula.plist` instance method](https://rubydoc.brew.sh/Formula.html#plist-instance_method)
- [`Formula.plist_options` class method](https://rubydoc.brew.sh/Formula.html#plist_options-class_method)
- [`Formula.service` class method](https://rubydoc.brew.sh/Formula.html#service-class_method)

# Miscellaneous

I wasn't attempting to install or use [`vm-proxy`](https://github.com/blacktop/vm-proxy), but received the above error when using commands that scan all Formulae (such as `brew uses <formula> --eval-all`). Just the existence of a broken formula file results in errors being written to the console when `blacktop/homebrew-tap` has been tapped.

I tried to test the changes, but I have an M1 Mac and don't have VirtualBox installed and `vm-proxy` segfaulted any time I tried to use it. It passed `brew typecheck` at least 👍